### PR TITLE
Refactor to use primary constructors and update namespaces

### DIFF
--- a/LinkShortener.Api/Controllers/ShortenerController.cs
+++ b/LinkShortener.Api/Controllers/ShortenerController.cs
@@ -6,14 +6,9 @@ namespace LinkShortener.Api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class ShortenerController : ControllerBase
+    public class ShortenerController(IUrlShorteningAppService shorteningService) : ControllerBase
     {
-        private readonly IUrlShorteningAppService _shorteningService;
-
-        public ShortenerController(IUrlShorteningAppService shorteningService)
-        {
-            _shorteningService = shorteningService;
-        }
+        private readonly IUrlShorteningAppService _shorteningService = shorteningService;
 
         [HttpPost("shorten")]
         public async Task<IActionResult> Shorten([FromBody] ShortenUrlRequest request)

--- a/LinkShortener.Application/LinkShortener.Application.csproj
+++ b/LinkShortener.Application/LinkShortener.Application.csproj
@@ -1,14 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="MediatR" Version="13.0.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="MediatR" Version="13.0.0" />
+		<PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\LinkShortener.Domain\LinkShortener.Domain.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/LinkShortener.Domain/Entities/ShortenedUrl.cs
+++ b/LinkShortener.Domain/Entities/ShortenedUrl.cs
@@ -1,4 +1,4 @@
-﻿namespace LinkShortener.Entities
+﻿namespace LinkShortener.Domain.Entities
 {
     public class ShortenedUrl
     {

--- a/LinkShortener.Infrastructure/ApplicationDbContext.cs
+++ b/LinkShortener.Infrastructure/ApplicationDbContext.cs
@@ -1,16 +1,11 @@
-﻿using LinkShortener.Entities;
+﻿using LinkShortener.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 
 namespace LinkShortener.Infrastructure
 {
-    public class ApplicationDbContext : DbContext
+    public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : DbContext(options)
     {
         private const int NumberOfCharsInShortlink = 7;
-
-        public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
-            : base(options)
-        {
-        }
 
         public DbSet<ShortenedUrl> ShortenedUrls { get; set; } = null!;
 
@@ -20,7 +15,7 @@ namespace LinkShortener.Infrastructure
             ConfigureShortenedUrlEntity(modelBuilder);
         }
 
-        private void ConfigureShortenedUrlEntity(ModelBuilder modelBuilder)
+        private static void ConfigureShortenedUrlEntity(ModelBuilder modelBuilder)
         {
             modelBuilder.Entity<ShortenedUrl>(builder =>
             {

--- a/LinkShortener.Infrastructure/Services/UrlShorteningAppService.cs
+++ b/LinkShortener.Infrastructure/Services/UrlShorteningAppService.cs
@@ -1,25 +1,18 @@
 ﻿using LinkShortener.Application.Abstractions;
-using LinkShortener.Entities;
+using LinkShortener.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 
 namespace LinkShortener.Infrastructure.Services
 {
-    public class UrlShorteningAppService : IUrlShorteningAppService
+    public class UrlShorteningAppService(
+        UrlShorteningService urlShorteningService,
+        ApplicationDbContext dbContext,
+        IMemoryCache cache) : IUrlShorteningAppService
     {
-        private readonly UrlShorteningService _urlShorteningService;
-        private readonly ApplicationDbContext _dbContext;
-        private readonly IMemoryCache _cache;
-
-        public UrlShorteningAppService(
-            UrlShorteningService urlShorteningService,
-            ApplicationDbContext dbContext,
-            IMemoryCache cache)
-        {
-            _urlShorteningService = urlShorteningService;
-            _dbContext = dbContext;
-            _cache = cache;
-        }
+        private readonly UrlShorteningService _urlShorteningService = urlShorteningService;
+        private readonly ApplicationDbContext _dbContext = dbContext;
+        private readonly IMemoryCache _cache = cache;
 
         public async Task<string> ShortenUrlAsync(string url, string scheme, string host)
         {

--- a/LinkShortener.Infrastructure/Services/UrlShorteningService.cs
+++ b/LinkShortener.Infrastructure/Services/UrlShorteningService.cs
@@ -1,23 +1,17 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
-using LinkShortener.Entities;
 
 namespace LinkShortener.Infrastructure.Services
 {
-    public class UrlShorteningService
+    public class UrlShorteningService(ApplicationDbContext context, IMemoryCache cache)
     {
         public const int NumberOfCharsInShortlink = 7;
         private const string Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
         private readonly Random _random = new();
-        private readonly ApplicationDbContext _context;
-        private readonly IMemoryCache _cache;
+        private readonly ApplicationDbContext _context = context;
+        private readonly IMemoryCache _cache = cache;
 
-        public UrlShorteningService(ApplicationDbContext context, IMemoryCache cache)
-        {
-            _context = context;
-            _cache = cache;
-        }
         public async Task<string> GenerateUniqueCode()
         {
             while (true)


### PR DESCRIPTION
Refactored controllers and services to use C# primary constructors for dependency injection, simplifying field initialization. Updated namespaces for domain entities and fixed project references. Adjusted project file to reference the domain project and corrected MediatR dependency version.